### PR TITLE
Update vuln_scans to only scan for critical, high, and med vulns

### DIFF
--- a/mesa_toolkit/lib/mesa_scans.py
+++ b/mesa_toolkit/lib/mesa_scans.py
@@ -225,19 +225,21 @@ def vuln_scans(rv_num, input_file=None, exclude_file=None):
     os.system('mkdir -p '+vuln_scan_folders)
     os.chdir(vuln_scan_folders)
 
-    run_command('nuclei -l '+input_file+' -etags default-login -headless -j -o '+rv_num+'_Vulnerability_Scan.txt', write_start_file=True)
+    run_command('nuclei -l '+input_file+' -etags default-login -s critical,high,medium -headless -j -o '+rv_num+'_Vulnerability_Scan.txt', write_start_file=True)
     run_command('cat '+rv_num+'_Vulnerability_Scan.txt |jq > '+rv_num+'_all_findings.json')
     run_command('cat '+rv_num+'_Vulnerability_Scan.txt |grep \'"severity"\':\'"critical"\'|jq > '+rv_num+'_critical_findings.json')
     run_command('cat '+rv_num+'_Vulnerability_Scan.txt |grep \'"severity"\':\'"high"\'|jq > '+rv_num+'_high_findings.json')
     run_command('cat '+rv_num+'_Vulnerability_Scan.txt |grep \'"severity"\':\'"medium"\'|jq > '+rv_num+'_medium_findings.json')
-    run_command('cat '+rv_num+'_Vulnerability_Scan.txt |grep \'"severity"\':\'"low"\'|jq > '+rv_num+'_low_findings.json')
-    run_command('cat '+rv_num+'_Vulnerability_Scan.txt |grep \'"severity"\':\'"info"\'|jq > '+rv_num+'_informational_findings.json')
-    run_command('cat '+rv_num+'_Vulnerability_Scan.txt |grep \'"severity"\':\'"unknown"\'|jq > '+rv_num+'_unknown_findings.json')
+    # Leaving these lines in the event that these findings get incorporated back into the scans
+    #run_command('cat '+rv_num+'_Vulnerability_Scan.txt |grep \'"severity"\':\'"low"\'|jq > '+rv_num+'_low_findings.json')
+    #run_command('cat '+rv_num+'_Vulnerability_Scan.txt |grep \'"severity"\':\'"info"\'|jq > '+rv_num+'_informational_findings.json')
+    #run_command('cat '+rv_num+'_Vulnerability_Scan.txt |grep \'"severity"\':\'"unknown"\'|jq > '+rv_num+'_unknown_findings.json')
     run_command('cat '+rv_num+'_critical_findings.json |jq -r \'.info.severity + " - " + .info.name + " - " + .host\'|sort -u > '+rv_num+'_critical_affected_hosts.txt')
     run_command('cat '+rv_num+'_high_findings.json |jq -r \'.info.severity + " - " + .info.name + " - " + .host\'|sort -u > '+rv_num+'_high_affected_hosts.txt')
     run_command('cat '+rv_num+'_medium_findings.json |jq -r \'.info.severity + " - " + .info.name + " - " + .host\'|sort -u > '+rv_num+'_medium_affected_hosts.txt')
-    run_command('cat '+rv_num+'_low_findings.json |jq -r \'.info.severity + " - " + .info.name + " - " + .host\'|sort -u > '+rv_num+'_low_affected_hosts.txt')
-    run_command('cat '+rv_num+'_informational_findings.json |jq -r \'.info.severity + " - " + .info.name + " - " + .host\'|sort -u > '+rv_num+'_informational_affected_hosts.txt', write_complete_file=True)
+    # Leaving these lines in the event that these findings get incorporated back into the scans
+    #run_command('cat '+rv_num+'_low_findings.json |jq -r \'.info.severity + " - " + .info.name + " - " + .host\'|sort -u > '+rv_num+'_low_affected_hosts.txt')
+    #run_command('cat '+rv_num+'_informational_findings.json |jq -r \'.info.severity + " - " + .info.name + " - " + .host\'|sort -u > '+rv_num+'_informational_affected_hosts.txt', write_complete_file=True)
 
     cleanup_empty_files()
     os.chdir(home)


### PR DESCRIPTION
## 🗣 Description ##

Updated the vulnerability scans function to only scan for critical, high, and medium vulnerabilities to minimize the amount of time spent scanning a network.

## 💭 Motivation and context ##

Scans were taking an excessive amount of time to complete in large part due to the number of templates being used by Nuclei. Reducing the severity ratings scanned will reduce the number of requests sent to each asset by multiple thousands. This will translate to a reduction in the amount of time it takes to perform a scan on the provided network range.

## 🧪 Testing ##

- [ ] Validate the tool still runs as expected and that the following command does not produce any files for informational, low, or unknown findings:
          
`MESA-Toolkit -o vuln_scans -p <Project_Name> -i <Target_File>`

## ✅ Pre-approval checklist ##

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.