### PR TITLE
Remove service enumeration checks from full port nmap scans

### DIFF
--- a/mesa_toolkit/lib/mesa_scans.py
+++ b/mesa_toolkit/lib/mesa_scans.py
@@ -182,7 +182,7 @@ def full_port(rv_num, input_file=None, exclude_file=None):
 
     nmap_folders_full = rv_num+NMAP_FOLDERS_FULL
     os.system('mkdir -p '+nmap_folders_full)
-    run_command('nmap -Pn -n -sV -p- --min-hostgroup 255 --min-rtt-timeout 0ms --max-rtt-timeout 100ms --max-retries 1 --max-scan-delay 0 --min-rate 2000 -vvv --open -oA '+nmap_folders_full+rv_num+'_FULL'+' '+'-iL '+input_file, path=nmap_folders_full, write_start_file=True)
+    run_command('nmap -Pn -n -p- --min-hostgroup 255 --min-rtt-timeout 0ms --max-rtt-timeout 100ms --max-retries 1 --max-scan-delay 0 --min-rate 2000 -vvv --open -oA '+nmap_folders_full+rv_num+'_FULL'+' '+'-iL '+input_file, path=nmap_folders_full, write_start_file=True)
     os.chdir(nmap_folders_full)
     run_gnmap_parser()
     mark_folder_complete(completion_status="0")


### PR DESCRIPTION
## 🗣 Description ##

Updated nmap full port scans to no longer perform service enumeration checks.

## 💭 Motivation and context ##

Full port scans were taking an excessive amount of time to complete due to service enumeration checks. Removing service enumeration checks will substantially reduce the amount of time it takes for the full port nmap scans to complete. 

## 🧪 Testing ##

[ ] Validate the tool still runs as expected and that service enumeration checks are not being performed against provided input range:

`MESA-Toolkit -o full -p <Project_Name> -i <Target_File>` 

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert dependencies to default branches.
- [x] Finalize version.