### PR TITLE
Add ability to provide exclude file to full port scan operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changelog
-## [v0.3.0] - 04/26/2024
+## [v0.4.0] - 04/26/2024
 - Add ability to provide exclude file to full port scan operation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changelog
-## [v0.1.0] - XX/XX/XXXX
-- Initial commit
+## [v0.3.0] - 04/26/2024
+- Add ability to provide exclude file to full port scan operation

--- a/mesa_toolkit/lib/mesa_scans.py
+++ b/mesa_toolkit/lib/mesa_scans.py
@@ -182,7 +182,10 @@ def full_port(rv_num, input_file=None, exclude_file=None):
 
     nmap_folders_full = rv_num+NMAP_FOLDERS_FULL
     os.system('mkdir -p '+nmap_folders_full)
-    run_command('nmap -Pn -n -sV -p- --min-hostgroup 255 --min-rtt-timeout 0ms --max-rtt-timeout 100ms --max-retries 1 --max-scan-delay 0 --min-rate 2000 -vvv --open -oA '+nmap_folders_full+rv_num+'_FULL'+' '+'-iL '+input_file, path=nmap_folders_full, write_start_file=True)
+    if exclude_file:
+        run_command('nmap -Pn -n -p- --min-hostgroup 255 --min-rtt-timeout 0ms --max-rtt-timeout 100ms --max-retries 1 --max-scan-delay 0 --min-rate 2000 -vvv --open -oA '+nmap_folders_full+rv_num+'_FULL'+' '+'-iL '+input_file+' --excludefile '+exclude_file, path=nmap_folders_full, write_start_file=True)
+    else:
+        run_command('nmap -Pn -n -p- --min-hostgroup 255 --min-rtt-timeout 0ms --max-rtt-timeout 100ms --max-retries 1 --max-scan-delay 0 --min-rate 2000 -vvv --open -oA '+nmap_folders_full+rv_num+'_FULL'+' '+'-iL '+input_file, path=nmap_folders_full, write_start_file=True)
     os.chdir(nmap_folders_full)
     run_gnmap_parser()
     mark_folder_complete(completion_status="0")


### PR DESCRIPTION
## 🗣 Description ##

This PR satisfies issue #5 

## 💭 Motivation and context ##

The full port scans were not properly accounting for exclude files when ran directly from the CLI. This could potentially be detrimental if the tool is ran without first using the scoper operation. 

## 🧪 Testing ##

- Added scripting logic to account for optional exclude files
- Loaded tool on a virtual machine and ran tool against test range
- Used the following commands to ensure full port operation worked with and without exclude files:

`MESA-Toolkit -o full -p <Project_Name> -i <Target_File>`
`MESA-Toolkit -o full -p <Project_Name> -i <Target_File> -e <Exclude_File>`

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert dependencies to default branches.
- [x] Finalize version.