### PR TITLE
Ensure .complete file is created after vulnerability scans complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
 # Changelog
-## [v0.1.0] - 02/27/2024
-- Initial commit
+## [v0.4.1] - 04/29/2024
+- Ensure .complete file is created after vulnerability scans complete. This is necessary for MESA-GUI to recognize when the vulnerability scans are done running. 
 
-## [v0.2.0] - 04/22/2024
-- Update vulnerability scans to scan for only critical, high, and medium vulnerabilites for time efficiency
+## [v0.4.0] - 04/26/2024
+- Add ability to provide exclude file to full port scan operation
 
 ## [v0.3.0] - 04/24/2024
 
 - Remove service enumeration checks from full port nmap scans
 
-## [v0.4.0] - 04/26/2024
-- Add ability to provide exclude file to full port scan operation
+## [v0.2.0] - 04/22/2024
+- Update vulnerability scans to scan for only critical, high, and medium vulnerabilites for time efficiency
 
-## [v0.4.1] - 04/29/2024
-- Ensure .complete file is created after vulnerability scans complete. This is necessary for MESA-GUI to recognize when the vulnerability scans are done running. 
+## [v0.1.0] - 02/27/2024
+- Initial commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
 # Changelog
-## [v0.5.0] - 04/29/2024
+## [v0.1.0] - 02/27/2024
+- Initial commit
+
+## [v0.2.0] - 04/22/2024
+- Update vulnerability scans to scan for only critical, high, and medium vulnerabilites for time efficiency
+
+## [v0.3.0] - 04/24/2024
+
+- Remove service enumeration checks from full port nmap scans
+
+## [v0.4.0] - 04/26/2024
+- Add ability to provide exclude file to full port scan operation
+
+## [v0.4.1] - 04/29/2024
 - Ensure .complete file is created after vulnerability scans complete. This is necessary for MESA-GUI to recognize when the vulnerability scans are done running. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changelog
-## [v0.4.0] - 04/26/2024
-- Add ability to provide exclude file to full port scan operation
+## [v0.5.0] - 04/29/2024
+- Ensure .complete file is created after vulnerability scans complete. This is necessary for MESA-GUI to recognize when the vulnerability scans are done running. 

--- a/mesa_toolkit/lib/mesa_scans.py
+++ b/mesa_toolkit/lib/mesa_scans.py
@@ -239,7 +239,7 @@ def vuln_scans(rv_num, input_file=None, exclude_file=None):
     #run_command('cat '+rv_num+'_Vulnerability_Scan.txt |grep \'"severity"\':\'"unknown"\'|jq > '+rv_num+'_unknown_findings.json')
     run_command('cat '+rv_num+'_critical_findings.json |jq -r \'.info.severity + " - " + .info.name + " - " + .host\'|sort -u > '+rv_num+'_critical_affected_hosts.txt')
     run_command('cat '+rv_num+'_high_findings.json |jq -r \'.info.severity + " - " + .info.name + " - " + .host\'|sort -u > '+rv_num+'_high_affected_hosts.txt')
-    run_command('cat '+rv_num+'_medium_findings.json |jq -r \'.info.severity + " - " + .info.name + " - " + .host\'|sort -u > '+rv_num+'_medium_affected_hosts.txt')
+    run_command('cat '+rv_num+'_medium_findings.json |jq -r \'.info.severity + " - " + .info.name + " - " + .host\'|sort -u > '+rv_num+'_medium_affected_hosts.txt', write_complete_file=True)
     # Leaving these lines in the event that these findings get incorporated back into the scans
     #run_command('cat '+rv_num+'_low_findings.json |jq -r \'.info.severity + " - " + .info.name + " - " + .host\'|sort -u > '+rv_num+'_low_affected_hosts.txt')
     #run_command('cat '+rv_num+'_informational_findings.json |jq -r \'.info.severity + " - " + .info.name + " - " + .host\'|sort -u > '+rv_num+'_informational_affected_hosts.txt', write_complete_file=True)


### PR DESCRIPTION
## 🗣 Description ##

The mesa-gui was not properly tracking when vulnerability scans were completed. This was due to a missing .complete file that is generated after the scans have finished running. 

## 💭 Motivation and context ##

This PR addresses issue #7.

## 🧪 Testing ##

1. Build the mesa-ops.ova using the mesa-packer repo (https://github.com/cisagov/mesa-packer.git)
2. Load the vm into VMware fusion
3. Run the All Checks option from the GUI after supplying the scope
4. Verify that the vulnerability scans are running on the backend as intended (sudo journalctl -fu mesa.service)
5. Verify the vulnerability scans are showing at `Complete` after they have successfully completed in the GUI

## ✅ Pre-approval checklist ##

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.
